### PR TITLE
Update pyproject.toml to support py 3.12 and Typer to newest release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dagster-ext"
-version = "0.1.0"
+version = "0.1.1"
 description = "`dagster-ext` is a Meltano utility extension."
 authors = ["Jules Huisman"]
 license = "Apache 2.0"
@@ -15,9 +15,9 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "<3.11,>=3.8"
+python = "<3.13,>=3.8"
 click = "^8.1.3"
-typer = "^0.6.1"
+typer = "^0.9.0"
 dagit = ">=1.0"
 dagster = ">=1.0"
 dagster-dbt = ">=0.16"


### PR DESCRIPTION
# What's Changed?
- Updated Python to 3.12 and Typer to use ^0.9.0 in the hopes of allows us to use latest Dagster vesrions.
- Addressing https://github.com/quantile-development/dagster-meltano/issues/42 and https://github.com/quantile-development/dagster-meltano/issues/48

![image](https://github.com/quantile-development/dagster-ext/assets/84326247/63cdb900-f71b-4d04-bf5a-27848ba7f2ad)
