### PR TITLE
Use `tool.poetry.homepage` instead of PEP 621 `project.urls`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "`dagster-ext` is a Meltano utility extension."
 authors = ["Jules Huisman"]
 license = "Apache 2.0"
 readme = "README.md"
+homepage = "https://github.com/quantile-development/dagster-ext"
 packages = [
     { include = "dagster_ext" },
     { include = "files_dagster_ext" },
@@ -39,9 +40,6 @@ pylint = "^2.15.3"
 [build-system]
 requires = ["poetry-core>=1.0.8"]
 build-backend = "poetry.core.masonry.api"
-
-[project.urls]
-Homepage = "https://github.com/quantile-development/dagster-ext"
 
 [tool.poetry.scripts]
 dagster_extension = 'dagster_ext.main:app'


### PR DESCRIPTION
Metadata before:

```
Metadata-Version: 2.1
Name: dagster-ext
Version: 0.1.1
Summary: `dagster-ext` is a Meltano utility extension.
License: Apache 2.0
Author: Jules Huisman
```

Metadata after:

```
Metadata-Version: 2.1
Name: dagster-ext
Version: 0.1.1
Summary: `dagster-ext` is a Meltano utility extension.
Home-page: https://github.com/quantile-development/dagster-ext
License: Apache 2.0
Author: Jules Huisman
```

Closes https://github.com/quantile-development/dagster-ext/issues/12
